### PR TITLE
Splitting side effects in models tests

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -9,6 +9,11 @@ config :rumbl, Rumbl.Endpoint,
 # Print only warnings and errors during test
 config :logger, level: :warn
 
+# Use low number of hashing rounds in tests to speed up users seeding
+config :comeonin,
+  bcrypt_log_rounds: 4,
+  bpkdf2_rounds: 1
+
 # Configure your database
 config :rumbl, Rumbl.Repo,
   adapter: Ecto.Adapters.Postgres,

--- a/test/controllers/auth_test.exs
+++ b/test/controllers/auth_test.exs
@@ -35,4 +35,15 @@ defmodule Rumbl.AuthTest do
     next_conn = get(login_conn, "/")
     assert get_session(next_conn, :user_id) == 123
   end
+
+  test "logout drops the session", %{conn: conn} do
+    logout_conn =
+      conn
+      |> put_session(:user_id, 123)
+      |> Auth.logout()
+      |> send_resp(:ok, "")
+
+    next_conn = get(logout_conn, "/")
+    refute get_session(next_conn, :user_id)
+  end
 end

--- a/test/controllers/auth_test.exs
+++ b/test/controllers/auth_test.exs
@@ -62,4 +62,21 @@ defmodule Rumbl.AuthTest do
 
     assert conn.assigns.current_user == nil
   end
+
+  test "login with a valid username and password", %{conn: conn} do
+    user = insert_user(username: "me", password: "secret123")
+    {:ok, conn} = Auth.login_by_username_and_pass(conn, "me", "secret123", repo: Repo)
+
+    assert conn.assigns.current_user.id == user.id
+  end
+
+  test "login with a non-existing user", %{conn: conn} do
+    assert {:error, :not_found, _conn} = Auth.login_by_username_and_pass(conn, "me", "secret123", repo: Repo)
+  end
+
+  test "login with missmatched password", %{conn: conn} do
+    _ = insert_user(username: "me", password: "secret567")
+
+    assert{:error, :unauthorized, _conn} = Auth.login_by_username_and_pass(conn, "me", "password123", repo: Repo)
+  end
 end

--- a/test/controllers/auth_test.exs
+++ b/test/controllers/auth_test.exs
@@ -25,4 +25,14 @@ defmodule Rumbl.AuthTest do
 
     refute conn.halted
   end
+
+  test "login puts the user in the session", %{conn: conn} do
+    login_conn =
+      conn
+      |> Auth.login(%Rumbl.User{id: 123})
+      |> send_resp(:ok, "")
+
+    next_conn = get(login_conn, "/")
+    assert get_session(next_conn, :user_id) == 123
+  end
 end

--- a/test/controllers/auth_test.exs
+++ b/test/controllers/auth_test.exs
@@ -1,0 +1,28 @@
+defmodule Rumbl.AuthTest do
+  use Rumbl.ConnCase
+  alias Rumbl.Auth
+
+  setup %{conn: conn} do
+    conn =
+      conn
+      |> bypass_through(Rumbl.Router, :browser)
+      |> get("/")
+
+    {:ok, %{conn: conn}}
+  end
+
+  test "authenticate_user halts when no current_user exists", %{conn: conn} do
+    conn = Auth.authenticate_user(conn, [])
+
+    assert conn.halted
+  end
+
+  test "authenticate_user continues when current_user exists", %{conn: conn} do
+    conn =
+      conn
+      |> assign(:current_user, %Rumbl.User{})
+      |> Auth.authenticate_user([])
+
+    refute conn.halted
+  end
+end

--- a/test/controllers/auth_test.exs
+++ b/test/controllers/auth_test.exs
@@ -46,4 +46,20 @@ defmodule Rumbl.AuthTest do
     next_conn = get(logout_conn, "/")
     refute get_session(next_conn, :user_id)
   end
+
+  test "call places user from session into assigns", %{conn: conn} do
+    user = insert_user()
+    conn =
+      conn
+      |> put_session(:user_id, user.id)
+      |> Auth.call(Repo)
+
+    assert conn.assigns.current_user.id == user.id
+  end
+
+  test "call with no session assigns nil to current_user", %{conn: conn} do
+    conn = Auth.call(conn, Repo)
+
+    assert conn.assigns.current_user == nil
+  end
 end

--- a/test/models/category_repo_test.exs
+++ b/test/models/category_repo_test.exs
@@ -1,0 +1,14 @@
+defmodule Rumbl.CategoryRepoTest do
+  use Rumbl.ModelCase
+  alias Rumbl.Category
+
+  test "alphabetical/1 orders by name" do
+    Repo.insert!(%Category{name: "A"})
+    Repo.insert!(%Category{name: "B"})
+    Repo.insert!(%Category{name: "C"})
+
+    query = Category |> Category.alphabetical()
+    query = from c in query, select: c.name
+    assert Repo.all(query) == ~w(A B C)
+  end
+end

--- a/test/models/user_repo_test.exs
+++ b/test/models/user_repo_test.exs
@@ -1,0 +1,15 @@
+defmodule Rumbl.UserRepoTest do
+  use Rumbl.ModelCase
+  alias Rumbl.User
+
+  @valid_attrs %{name: "A User", username: "Rafal"}
+
+  test "converts unique_constraint on username to error" do
+    insert_user(username: "eric")
+    attrs = Map.put(@valid_attrs, :username, "eric")
+    changeset = User.changeset(%User{}, attrs)
+
+    assert {:error, changeset} = Repo.insert(changeset)
+    assert {:username, "has already been taken"} in changeset.errors
+  end
+end

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -9,4 +9,9 @@ defmodule Rumbl.UserTest do
     changeset = User.changeset(%User{}, @valid_attrs)
     assert changeset.valid?
   end
+
+  test "changeset with invalid attributes" do
+    changeset = User.changeset(%User{}, @invalid_attrs)
+    refute changeset.valid?
+  end
 end

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -27,4 +27,14 @@ defmodule Rumbl.UserTest do
 
     assert {:password, {"Should be at least %{count} character(s)", count: 6}} in changeset.errors
   end
+
+  test "registration_changeset with valid attributes hashes password" do
+    attrs = Map.put(@valid_attrs, :password, "123456")
+    changeset = User.registration_changeset(%User{}, attrs)
+    %{password: pass, password_hash: pass_hash} = changeset.changes
+
+    assert changeset.valid?
+    assert pass_hash
+    assert Comeonin.Bcrypt.checkpw(pass, pass_hash)
+  end
 end

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -20,4 +20,11 @@ defmodule Rumbl.UserTest do
     assert {:username, {"should be at most %{count} character(s)", [count: 20]}} in
       errors_on(%User{}, attrs)
   end
+
+  test "registration_changeset password must be at leats 6 characters long" do
+    attrs = Map.put(@valid_attrs, :password, "12345")
+    changeset = User.registration_changeset(%User{}, attrs)
+
+    assert {:password, {"Should be at least %{count} character(s)", count: 6}} in changeset.errors
+  end
 end

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -14,4 +14,10 @@ defmodule Rumbl.UserTest do
     changeset = User.changeset(%User{}, @invalid_attrs)
     refute changeset.valid?
   end
+
+  test "changeset does not accept too long usernames" do
+    attrs = Map.put(@valid_attrs, :username, String.duplicate("a", 21))
+    assert {:username, {"should be at most %{count} character(s)", [count: 20]}} in
+      errors_on(%User{}, attrs)
+  end
 end

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -1,0 +1,12 @@
+defmodule Rumbl.UserTest do
+  use Rumbl.ModelCase, async: true
+  alias Rumbl.User
+
+  @valid_attrs %{username: "Tom", name: "Torotom", password: "Secret123"}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = User.changeset(%User{}, @valid_attrs)
+    assert changeset.valid?
+  end
+end

--- a/test/support/model_case.ex
+++ b/test/support/model_case.ex
@@ -22,6 +22,7 @@ defmodule Rumbl.ModelCase do
       import Ecto.Changeset
       import Ecto.Query
       import Rumbl.ModelCase
+      import Rumbl.TestHelpers
     end
   end
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -3,7 +3,7 @@ defmodule Rumbl.TestHelpers do
 
   def insert_user(attrs \\ %{}) do
     changes = Dict.merge(%{name: "Some User",
-      username: "user_#{Base.encode16(:crypto.strong_rand_bytes(8))}",
+      username: "user_#{Base.encode16(:crypto.strong_rand_bytes(4))}",
       password: "supersecret"}, attrs)
 
     %Rumbl.User{}

--- a/test/views/video_view_test.exs
+++ b/test/views/video_view_test.exs
@@ -15,4 +15,12 @@ defmodule Rumbl.VideoViewTest do
       assert String.contains?(content, video.title)
     end
   end
+
+  test "renders new.html", %{conn: conn} do
+    changeset = Rumbl.Video.changeset(%Rumbl.Video{})
+    categories = [{"dogs", 123}]
+    content = render_to_string(Rumbl.VideoView, "new.html", conn: conn, changeset: changeset, categories: categories)
+
+    assert String.contains?(content, "New video")
+  end
 end

--- a/test/views/video_view_test.exs
+++ b/test/views/video_view_test.exs
@@ -1,0 +1,18 @@
+defmodule Rumbl.VideoViewTest do
+  use Rumbl.ConnCase, async: true
+  import Phoenix.View
+
+  test "renders index.html", %{conn: conn} do
+    videos = [
+      %Rumbl.Video{id: 1, title: "Dogs", description: "Sweet puppies"},
+      %Rumbl.Video{id: 2, title: "Husky", description: "Super guard dog"}
+    ]
+
+    content = render_to_string(Rumbl.VideoView, "index.html", conn: conn, videos: videos)
+
+    assert String.contains?(content, "Listing videos")
+    for video <- videos do
+      assert String.contains?(content, video.title)
+    end
+  end
+end


### PR DESCRIPTION
## _"Splitting side effects in models tests"_ chapter from _"Programming phoenix"_ book.

In this chapter we have covered basics of model testing, including synchronous and asynchronous tests. We also decided when and how to split our tests to make them work faster.